### PR TITLE
fix search page for parent columns

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -29,7 +29,7 @@ class SearchController <  ApplicationController
     end
 
     # For the table query we only give a list of identifiers
-    record_names = query.select_map(model.identity)
+    record_names = query.select_map(:"#{model.table_name}__#{model.identity}")
 
     render json: { record_names: record_names }
   end


### PR DESCRIPTION
This lets you search across foreign keys in the Search tab - a holdover until the query builder works.