### PR TITLE
update search page queries

### DIFF
--- a/app/assets/javascripts/actions.js
+++ b/app/assets/javascripts/actions.js
@@ -1,4 +1,3 @@
 window.plotActions = require('./actions/plot_actions.js');
 window.timurActions = require('./actions/timur_actions.js');
 window.messageActions = require('./actions/message_actions.js');
-window.magmaActions = require('./actions/magma_actions.js');

--- a/app/assets/javascripts/actions/timur_actions.js
+++ b/app/assets/javascripts/actions/timur_actions.js
@@ -1,6 +1,7 @@
 import Vector from 'vector'
 import { getTSV, getView } from '../api/timur'
 import { showMessages } from './message_actions'
+import { requestDocuments } from './magma_actions'
 import Tab from '../readers/tab'
 
 var timurActions = {
@@ -23,7 +24,7 @@ var timurActions = {
           )
 
           dispatch(
-            magmaActions.requestDocuments(
+            requestDocuments(
               model_name, [ record_name ], tab.requiredAttributes()
             )
           )

--- a/app/assets/javascripts/api/timur.js
+++ b/app/assets/javascripts/api/timur.js
@@ -34,3 +34,35 @@ export const getView = (model_name, tab_name) =>
   )
     .then(checkStatus)
     .then(parseJSON)
+
+export const getDocuments = (model_name, record_names, attribute_names, collapse_tables) =>
+  fetch(
+    Routes.records_json_path(),
+    {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: headers('json', 'csrf'),
+      body: JSON.stringify({
+        model_name: model_name,
+        record_names: record_names,
+        attribute_names: attribute_names,
+        ...collapse_tables && { collapse_tables: true }
+      })
+    }
+  )
+    .then(checkStatus)
+    .then(parseJSON)
+
+export const postRevisions = (revision_data) =>
+  fetch(
+    Routes.update_model_path(),
+    {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: headers('csrf'),
+      body: revision_data
+    }
+  )
+    .then(checkStatus)
+    .then(parseJSON)
+

--- a/app/assets/javascripts/components/attribute.jsx
+++ b/app/assets/javascripts/components/attribute.jsx
@@ -1,5 +1,4 @@
-// this is a single div that will format a document to display the
-// value for a single attribute
+import { reviseDocument } from '../actions/magma_actions'
 
 var Attribute = React.createClass({
   render: function() {
@@ -12,7 +11,7 @@ var Attribute = React.createClass({
                 placeholder={ this.props.attribute.placeholder }
                 update={
                   function(value) {
-                    store.dispatch(magmaActions.reviseDocument(
+                    store.dispatch(reviseDocument(
                       self.props.document,
                       self.props.template,
                       self.props.attribute,

--- a/app/assets/javascripts/components/browser.js.jsx
+++ b/app/assets/javascripts/components/browser.js.jsx
@@ -9,6 +9,7 @@
 import Magma from 'magma'
 import BrowserTab from './browser_tab'
 import Tab from '../readers/tab'
+import { discardRevision, sendRevisions } from '../actions/magma_actions'
 
 var Browser = React.createClass({
   componentDidMount: function() {
@@ -135,17 +136,17 @@ Browser = connect(
         ))
       },
       discardRevision: function() {
-        dispatch(magmaActions.discardRevision(
+        dispatch(discardRevision(
           props.record_name,
           props.model_name
         ))
       },
       submitRevision: function(revision,success,error) {
-        var revisions = {}
-        revisions[props.record_name] = revision
-        dispatch(magmaActions.postRevisions(
+        dispatch(sendRevisions(
           props.model_name,
-          revisions,
+          {
+            [props.record_name] : revision
+          },
           success,
           error
         ))

--- a/app/assets/javascripts/components/checkbox_attribute.js.jsx
+++ b/app/assets/javascripts/components/checkbox_attribute.js.jsx
@@ -1,3 +1,5 @@
+import { reviseDocument } from '../actions/magma_actions'
+
 var CheckboxAttribute = React.createClass({
   render: function() {
     var self = this
@@ -8,7 +10,7 @@ var CheckboxAttribute = React.createClass({
                 onChange={
                   function(e) {
                     store.dispatch(
-                      magmaActions.reviseDocument(
+                      reviseDocument(
                         self.props.document,
                         self.props.template,
                         self.props.attribute,

--- a/app/assets/javascripts/components/collection_attribute.jsx
+++ b/app/assets/javascripts/components/collection_attribute.jsx
@@ -1,3 +1,5 @@
+import { reviseDocument } from '../actions/magma_actions'
+
 var CollectionList = React.createClass({
   getInitialState: function() {
     return { new_link_updated: false }
@@ -102,7 +104,7 @@ var CollectionAttribute = connect(
     return {
       reviseList: function(newlist) {
         dispatch(
-          magmaActions.reviseDocument(
+          reviseDocument(
             ownProps.document,
             ownProps.template,
             ownProps.attribute,

--- a/app/assets/javascripts/components/date_time_attribute.js.jsx
+++ b/app/assets/javascripts/components/date_time_attribute.js.jsx
@@ -1,3 +1,5 @@
+import { reviseDocument } from '../actions/magma_actions'
+
 var DateTimeView = React.createClass({
   render: function() {
     var self = this
@@ -80,7 +82,7 @@ var DateTimeAttribute = connect(
             && (changed_date == -1 
             || old_date.getTime() != changed_date.getTime())) {
           dispatch(
-            magmaActions.reviseDocument(
+            reviseDocument(
               props.document,
               props.template,
               props.attribute,

--- a/app/assets/javascripts/components/document_attribute.js.jsx
+++ b/app/assets/javascripts/components/document_attribute.js.jsx
@@ -1,3 +1,4 @@
+import { reviseDocument } from '../actions/magma_actions'
 
 var DocumentAttribute = React.createClass({
   render: function() {
@@ -8,7 +9,7 @@ var DocumentAttribute = React.createClass({
       return <div className="value">
                <input onChange={
                  function(e) {
-                   store.dispatch(magmaActions.reviseDocument(
+                   store.dispatch(reviseDocument(
                      self.props.document,
                      self.props.template,
                      self.props.attribute,

--- a/app/assets/javascripts/components/float_attribute.js.jsx
+++ b/app/assets/javascripts/components/float_attribute.js.jsx
@@ -1,3 +1,5 @@
+import { reviseDocument } from '../actions/magma_actions'
+
 var FloatAttribute = React.createClass({
   filter_keys: function(e) {
     if (Keycode.is_ctrl(e)) return true;
@@ -21,7 +23,7 @@ var FloatAttribute = React.createClass({
           update={
             function(value) {
               store.dispatch(
-                magmaActions.reviseDocument(
+                reviseDocument(
                   self.props.document,
                   self.props.template,
                   self.props.attribute,

--- a/app/assets/javascripts/components/identifier_search.jsx
+++ b/app/assets/javascripts/components/identifier_search.jsx
@@ -1,3 +1,5 @@
+import { requestIdentifiers } from '../actions/magma_actions'
+
 var IdentifierSearch = React.createClass({
   getInitialState: function() {
     return { match_string: '', has_focus: false }
@@ -96,7 +98,7 @@ IdentifierSearch = connect(
   function(dispatch,props) {
     return {
       requestIdentifiers: function() {
-        dispatch(magmaActions.requestIdentifiers())
+        dispatch(requestIdentifiers())
       }
     }
   }

--- a/app/assets/javascripts/components/image_attribute.js.jsx
+++ b/app/assets/javascripts/components/image_attribute.js.jsx
@@ -1,3 +1,5 @@
+import { reviseDocument } from '../actions/magma_actions'
+
 var ImageAttribute = React.createClass({
   render: function() {
     var self = this
@@ -7,7 +9,7 @@ var ImageAttribute = React.createClass({
                <input
                  onChange={
                    function(e) {
-                     store.dispatch(magmaActions.reviseDocument(
+                     store.dispatch(reviseDocument(
                        self.props.document,
                        self.props.template,
                        self.props.attribute,

--- a/app/assets/javascripts/components/integer_attribute.js.jsx
+++ b/app/assets/javascripts/components/integer_attribute.js.jsx
@@ -1,3 +1,5 @@
+import { reviseDocument } from '../actions/magma_actions'
+
 var IntegerAttribute = React.createClass({
   filter_keys: function(e) {
     if (Keycode.is_ctrl(e)) return true;
@@ -22,7 +24,7 @@ var IntegerAttribute = React.createClass({
                 update={
                   function(value) {
                     store.dispatch(
-                      magmaActions.reviseDocument(
+                      reviseDocument(
                         self.props.document,
                         self.props.template,
                         self.props.attribute,

--- a/app/assets/javascripts/components/link_attribute.jsx
+++ b/app/assets/javascripts/components/link_attribute.jsx
@@ -1,3 +1,5 @@
+import { reviseDocument } from '../actions/magma_actions'
+
 var LinkAttribute = React.createClass({
   render: function() {
     var link = this.props.value
@@ -11,7 +13,7 @@ var LinkAttribute = React.createClass({
           <span className="delete_link"
           onClick={
             function(e) {
-              store.dispatch(magmaActions.reviseDocument(
+              store.dispatch(reviseDocument(
                 self.props.document,
                 self.props.template,
                 self.props.attribute,
@@ -27,7 +29,7 @@ var LinkAttribute = React.createClass({
                   waitTime={500}
                   update={
                     function(value) {
-                      store.dispatch(magmaActions.reviseDocument(
+                      store.dispatch(reviseDocument(
                         self.props.document,
                         self.props.template,
                         self.props.attribute,

--- a/app/assets/javascripts/components/markdown_attribute.jsx
+++ b/app/assets/javascripts/components/markdown_attribute.jsx
@@ -1,3 +1,5 @@
+import { reviseDocument } from '../actions/magma_actions'
+
 var MarkdownAttribute = React.createClass({
   render: function() {
     var store = this.context.store
@@ -8,7 +10,7 @@ var MarkdownAttribute = React.createClass({
                 onChange={
                   function(e) {
                     store.dispatch(
-                      magmaActions.reviseDocument(
+                      reviseDocument(
                         self.props.document,
                         self.props.template,
                         self.props.attribute,

--- a/app/assets/javascripts/components/select_attribute.js.jsx
+++ b/app/assets/javascripts/components/select_attribute.js.jsx
@@ -1,3 +1,5 @@
+import { reviseDocument } from '../actions/magma_actions'
+
 var SelectAttribute = React.createClass({
   render: function() {
     var self = this
@@ -8,7 +10,7 @@ var SelectAttribute = React.createClass({
                 className="selection"
                 onChange={
                   function(value) {
-                    store.dispatch(magmaActions.reviseDocument(
+                    store.dispatch(reviseDocument(
                       self.props.document,
                       self.props.template,
                       self.props.attribute,

--- a/app/assets/javascripts/components/text_attribute.js.jsx
+++ b/app/assets/javascripts/components/text_attribute.js.jsx
@@ -1,3 +1,5 @@
+import { reviseDocument } from '../actions/magma_actions'
+
 var TextAttribute = React.createClass({
   render: function() {
     var store = this.context.store
@@ -8,7 +10,7 @@ var TextAttribute = React.createClass({
                 onChange={
                   function(e) {
                     store.dispatch(
-                      magmaActions.reviseDocument(
+                      reviseDocument(
                         self.props.document,
                         self.props.template,
                         self.props.attribute,


### PR DESCRIPTION
This (1) uses the fetch api for posting queries from the search page (2) gets rid of the 'magmaActions' global and (3) uses collapse_tables to retrieve records more quickly from magma.