### PR TITLE
sort nil values last

### DIFF
--- a/app/models/table_query.rb
+++ b/app/models/table_query.rb
@@ -36,7 +36,9 @@ class TableQuery
     return nil unless @order && column(@order)
     @ordering ||= row_names.map.with_index do |row_name, i|
       [ column(@order)[row_name], i ]
-    end.sort_by(&:first).map(&:last)
+    end.sort do |a,b|
+      (a.first && b.first) ? (a.first <=> b.first) : (a.first ? -1 : 1 )
+    end.map(&:last)
   end
 
   def row_names


### PR DESCRIPTION
Just a simple bug-fix to prevent nil values from crashing the ordering of tables