### PR TITLE
Graft add view models

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -40,8 +40,8 @@ class BrowseController < ApplicationController
   end
 
   def view_json
-    tab = params[:tab_name] ? params[:tab_name].to_sym : nil
-    view = TimurView.create(params[:model_name], tab)
+    tab_name = params[:tab_name] ? params[:tab_name].to_sym : nil
+    view = ViewPane.create(params[:model_name], params[:project_name], tab_name)
     render(json: view)
   end
 

--- a/app/models/view_attribute.rb
+++ b/app/models/view_attribute.rb
@@ -1,0 +1,3 @@
+class ViewAttribute < ActiveRecord::Base
+  belongs_to :view_pane
+end

--- a/app/models/view_attribute.rb
+++ b/app/models/view_attribute.rb
@@ -1,3 +1,16 @@
 class ViewAttribute < ActiveRecord::Base
   belongs_to :view_pane
+
+  def to_hash
+    {
+      name: name,
+      attribute: {
+        name: name,
+        attribute_class: attribute_class,
+        display_name: display_name,
+        plot: plot,
+        placeholder: placeholder
+      }.reject { |k,v| v.nil? }
+    }
+  end
 end

--- a/app/models/view_pane.rb
+++ b/app/models/view_pane.rb
@@ -1,2 +1,55 @@
 class ViewPane < ActiveRecord::Base
+  has_many :view_attributes
+  def self.create(model_name, project_name, load_tab_name)
+    # first collect all of the panes matching this thing
+    panes = self.where(view_model_name: model_name, project_name: project_name).order(:created_at).all
+    if panes.empty?
+      return {
+        tabs: {
+          default: {
+            panes: {
+              default: {
+                title: nil,
+                display: []
+              }
+            }
+          }
+        },
+        tab_name: "default"
+      }
+    end
+
+    load_tab_name ||= panes.first.tab_name
+    tabs = panes.group_by(&:tab_name)
+
+    return {
+      tabs: Hash[
+        tabs.map do |tab_name, panes|
+          if (tab_name != load_tab_name.to_s)
+            next [ tab_name, nil ]
+          end
+          [
+            tab_name, {
+              panes: Hash[
+                panes.map do |pane|
+                  [
+                    pane.name,
+                    pane.to_hash
+                  ]
+                end
+              ]
+            }
+          ]
+        end
+      ],
+      tab_name: load_tab_name
+    }
+  end
+
+  def to_hash
+    {
+      title: title,
+      display: view_attributes.map(&:to_hash)
+    }
+  end
 end

--- a/app/models/view_pane.rb
+++ b/app/models/view_pane.rb
@@ -1,0 +1,2 @@
+class ViewPane < ActiveRecord::Base
+end

--- a/db/migrate/20170907162238_create_view_panes.rb
+++ b/db/migrate/20170907162238_create_view_panes.rb
@@ -1,0 +1,12 @@
+class CreateViewPanes < ActiveRecord::Migration
+  def change
+    create_table :view_panes do |t|
+      t.string :tab_name
+      t.string :name
+      t.string :title
+      t.string :description
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20170907163036_create_view_attributes.rb
+++ b/db/migrate/20170907163036_create_view_attributes.rb
@@ -1,0 +1,15 @@
+class CreateViewAttributes < ActiveRecord::Migration
+  def change
+    create_table :view_attributes do |t|
+      t.string :name
+      t.string :attribute_class
+      t.string :display_name
+      t.json :plot
+      t.string :placeholder
+      t.integer :view_pane_id
+
+      t.timestamps null: false
+    end
+    add_index('view_attributes', 'view_pane_id')
+  end
+end

--- a/db/migrate/20170907204612_add_model_to_view_pane.rb
+++ b/db/migrate/20170907204612_add_model_to_view_pane.rb
@@ -1,0 +1,6 @@
+class AddModelToViewPane < ActiveRecord::Migration
+  def change
+    add_column :view_panes, :model_name, :string
+    add_column :view_panes, :project_name, :string
+  end
+end

--- a/db/migrate/20170907212225_rename_model_name.rb
+++ b/db/migrate/20170907212225_rename_model_name.rb
@@ -1,0 +1,5 @@
+class RenameModelName < ActiveRecord::Migration
+  def change
+    rename_column :view_panes, :model_name, :view_model_name
+  end
+end

--- a/lib/tasks/make_panes.rake
+++ b/lib/tasks/make_panes.rake
@@ -1,3 +1,6 @@
+# This task takes the existing view classes (built for the IPI project) and
+# turns them into records in the view_panes and view_attributes tables.
+
 namespace :timur do
   desc "Create view models from view classes"
   task :make_view_model => [:environment] do |t,args|

--- a/lib/tasks/make_panes.rake
+++ b/lib/tasks/make_panes.rake
@@ -1,0 +1,32 @@
+namespace :timur do
+  desc "Create view models from view classes"
+  task :make_view_model => [:environment] do |t,args|
+    views = [ SampleView, ProjectView, RnaSeqPlateView, PatientView, ExperimentView ]
+    views.each do |view|
+      model_name = view.name.sub(/View/,'').snake_case
+      view.tabs.each do |tab_name,tab_block|
+        tab = TimurView::Tab.new(tab_name, &tab_block)
+        tab.panes.each do |pane_name, pane|
+          view_pane = ViewPane.create(
+            view_model_name: model_name,
+            project_name: "ipi",
+            tab_name: tab_name,
+            name: pane_name,
+            title: pane.instance_variable_get("@title")
+          )
+          pane.display.each do |display|
+            att = display.attribute
+            view_att = ViewAttribute.create(
+              name: att[:name],
+              attribute_class: att[:attribute_class],
+              display_name: att[:display_name],
+              plot: att[:plot].to_json,
+              placeholder: att[:placeholder],
+              view_pane: view_pane
+            )
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Uncouples the view models from the codebase by putting the view into the database.

This means in the near future in order to add things to the view you will have to create or update the view records. There is no facility for doing this - you must either write a rake task or make the edits by hand.

In the far future we should add tools to help edit the view.

Note that I have not yet removed the 'SampleView' etc. models even though they are unused, so that the timur:make_view_models rake task will continue working while this PR is being tested.