### PR TITLE
Graft fix view models

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -41,7 +41,7 @@ class BrowseController < ApplicationController
 
   def view_json
     tab_name = params[:tab_name] ? params[:tab_name].to_sym : nil
-    view = ViewPane.create(params[:model_name], params[:project_name], tab_name)
+    view = ViewPane.build_view(params[:model_name], params[:project_name], tab_name)
     render(json: view)
   end
 

--- a/app/models/timur_view.rb
+++ b/app/models/timur_view.rb
@@ -26,7 +26,7 @@
 
 class TimurView
   class Tab
-    attr_reader :name
+    attr_reader :name, :panes
 
     def initialize(name, &block)
       @name = name
@@ -104,6 +104,8 @@ class TimurView
       instance_eval(&block) if block_given?
     end
 
+    attr_reader :attribute
+
     [ :attribute_class, :display_name, :plot, :placeholder ].each do |name|
       define_method name do |txt|
         @attribute[name] = txt
@@ -127,7 +129,7 @@ class TimurView
       instance_eval( &block )
     end
 
-    attr_reader :attributes
+    attr_reader :attributes, :display
 
     def to_hash
       {

--- a/app/models/timur_view.rb
+++ b/app/models/timur_view.rb
@@ -38,52 +38,16 @@ class TimurView
       @panes[name] = Pane.new(name,&block)
     end
 
-#   It doesn't seem like this function gets used. We should verify this and
-#   remove it if necessary.
 
-#   def load(record_name)
-#
-#     puts 'sup'
-#     puts sessions[:token]
-#     puts 'mang'
-#
-#     #uri = URI.parse('https://magma-dev.ucsf-immunoprofiler.org/retrieve')
-#     uri = URI.parse('https://magma-dev.ucsf.edu:3000/retrieve')
-#     http = Net::HTTP.new(uri.host, uri.port)
-#     http.use_ssl = true
-#     http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-#
-#     form_data = {
-#       model_name: @model_name,
-#       record_names: [record_name],
-#       hide_tables: true
-#     }
-#
-#     header_data = {
-#       'Content-Type'=> 'application/json',
-#       'Accept'=> 'application/json'
-#     }
-#
-#     response = http.post(uri.path, form_data.to_json, header_data)
-#
-#     response.each_header do |header, value|
-#       puts "#{header}\t#{value}"
-#     end
-#
-#     if response.code == 200
-#       @payload = JSON.parse(response.body)
-#     end
-#   end
-
-   def to_hash
-     {
-       panes: Hash[
-         @panes.map do |name, pane|
-           [ name, pane.to_hash ]
-         end
-       ]
-     }
-   end
+    def to_hash
+      {
+        panes: Hash[
+          @panes.map do |name, pane|
+            [ name, pane.to_hash ]
+          end
+        ]
+      }
+    end
 
     private
 

--- a/app/models/view_pane.rb
+++ b/app/models/view_pane.rb
@@ -16,7 +16,7 @@ class ViewPane < ActiveRecord::Base
             }
           }
         },
-        tab_name: "default"
+        tab_name: 'default'
       }
     end
 

--- a/app/models/view_pane.rb
+++ b/app/models/view_pane.rb
@@ -1,6 +1,7 @@
 class ViewPane < ActiveRecord::Base
   has_many :view_attributes
-  def self.create(model_name, project_name, load_tab_name)
+
+  def self.build_view(model_name, project_name, load_tab_name)
     # first collect all of the panes matching this thing
     panes = self.where(view_model_name: model_name, project_name: project_name).order(:created_at).all
     if panes.empty?

--- a/app/models/view_pane.rb
+++ b/app/models/view_pane.rb
@@ -1,5 +1,5 @@
 class ViewPane < ActiveRecord::Base
-  has_many :view_attributes
+  has_many :view_attributes, dependent: :destroy
 
   def self.build_view(model_name, project_name, load_tab_name)
     # first collect all of the panes matching this thing

--- a/lib/tasks/make_panes.rake
+++ b/lib/tasks/make_panes.rake
@@ -4,12 +4,22 @@
 namespace :timur do
   desc "Create view models from view classes"
   task :make_view_model => [:environment] do |t,args|
+
+    # Start with a clean slate
+    ViewPane.delete_all
+    ViewAttribute.delete_all
+
+    # Collect the old View classes
     views = [ SampleView, ProjectView, RnaSeqPlateView, PatientView, ExperimentView ]
+
     views.each do |view|
       model_name = view.name.sub(/View/,'').snake_case
       view.tabs.each do |tab_name,tab_block|
         tab = TimurView::Tab.new(tab_name, &tab_block)
         tab.panes.each do |pane_name, pane|
+
+          # Build a new ViewPane from this Pane
+
           view_pane = ViewPane.create(
             view_model_name: model_name,
             project_name: "ipi",
@@ -17,6 +27,9 @@ namespace :timur do
             name: pane_name,
             title: pane.instance_variable_get("@title")
           )
+
+          # Build the pane's ViewAttributes
+          
           pane.display.each do |display|
             att = display.attribute
             view_att = ViewAttribute.create(

--- a/lib/tasks/make_view_models.rake
+++ b/lib/tasks/make_view_models.rake
@@ -3,11 +3,10 @@
 
 namespace :timur do
   desc "Create view models from view classes"
-  task :make_view_model => [:environment] do |t,args|
+  task :make_view_models => [:environment] do |t,args|
 
     # Start with a clean slate
-    ViewPane.delete_all
-    ViewAttribute.delete_all
+    ViewPane.where(project_name: "ipi").destroy_all
 
     # Collect the old View classes
     views = [ SampleView, ProjectView, RnaSeqPlateView, PatientView, ExperimentView ]

--- a/lib/tasks/make_view_models.rake
+++ b/lib/tasks/make_view_models.rake
@@ -2,11 +2,11 @@
 # turns them into records in the view_panes and view_attributes tables.
 
 namespace :timur do
-  desc "Create view models from view classes"
+  desc 'Create view models from view classes'
   task :make_view_models => [:environment] do |t,args|
 
     # Start with a clean slate
-    ViewPane.where(project_name: "ipi").destroy_all
+    ViewPane.where(project_name: 'ipi').destroy_all
 
     # Collect the old View classes
     views = [ SampleView, ProjectView, RnaSeqPlateView, PatientView, ExperimentView ]
@@ -21,10 +21,10 @@ namespace :timur do
 
           view_pane = ViewPane.create(
             view_model_name: model_name,
-            project_name: "ipi",
+            project_name: 'ipi',
             tab_name: tab_name,
             name: pane_name,
-            title: pane.instance_variable_get("@title")
+            title: pane.instance_variable_get('@title')
           )
 
           # Build the pane's ViewAttributes


### PR DESCRIPTION
The chain of events which led to error:

1. I wrote the ViewPane and ViewAttribute models.

2. I created the rake task to load the data for these models from the old TimurView classes. This required exposing certain attributes on the TimurView / Tab / Pane / DisplayAttribute models.

3. I wrote the view_json controller to use the new ViewPane and ViewAttributes model. I added a "create" class method to ViewPane to support this (thereby accidentally overwriting ActiveRecord::Base#create).

4. I couldn't remember why I had exposed those attributes on TimurView, which seemed unnecessary, so never committed those changes.

I fixed both of these things and also made the rake task clean out the existing models before proceeding.