### PR TITLE
fix update controller action + add browse route

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -47,12 +47,12 @@ class BrowseController < ApplicationController
 
   def update
     begin
-      status, payload = Magma::Client.instance.update(
+      response = Magma::Client.instance.update(
         token,
         params[:project_name],
         params[:revisions]
       )
-      render json: payload
+      render json: response.body
     rescue Magma::ClientError => e
       render json: e.body, status: e.status
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,8 @@ Rails.application.routes.draw do
   get 'auth_error'=> 'welcome#auth_error', as: :auth_error
 
   # browse_controller.rb
-  get ':project_name'=> 'browse#index', as: :browse
-  get ':project_name/browse'=> 'browse#index', as: :browse2
+  get ':project_name'=> 'browse#index', as: :project_path
+  get ':project_name/browse'=> 'browse#index', as: :browse_path
   get ':project_name/activity'=> 'browse#activity', as: :activity
   get ':project_name/browse/:model_name/*record_name'=> 'browse#model', as: :browse_model, format: false
   get ':project_name/map'=> 'browse#map', as: :map

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   # browse_controller.rb
   get ':project_name'=> 'browse#index', as: :browse
+  get ':project_name/browse'=> 'browse#index', as: :browse2
   get ':project_name/activity'=> 'browse#activity', as: :activity
   get ':project_name/browse/:model_name/*record_name'=> 'browse#model', as: :browse_model, format: false
   get ':project_name/map'=> 'browse#map', as: :map

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,8 @@ Rails.application.routes.draw do
   get 'auth_error'=> 'welcome#auth_error', as: :auth_error
 
   # browse_controller.rb
-  get ':project_name'=> 'browse#index', as: :project_path
-  get ':project_name/browse'=> 'browse#index', as: :browse_path
+  get ':project_name'=> 'browse#index', as: :project
+  get ':project_name/browse'=> 'browse#index', as: :browse
   get ':project_name/activity'=> 'browse#activity', as: :activity
   get ':project_name/browse/:model_name/*record_name'=> 'browse#model', as: :browse_model, format: false
   get ':project_name/map'=> 'browse#map', as: :map


### PR DESCRIPTION
For some reason I failed to validate the update controller, which still uses the old Magma gem syntax. Also there was no /:project_name/browse/ route as there was on the old site, so I added that in.