### PR TITLE
change root page layout

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,5 +1,5 @@
 class WelcomeController < ApplicationController
-  layout 'application'
+  layout 'timur'
   before_filter :authenticate, except: :no_auth
 
   def index


### PR DESCRIPTION
The root page seems to use a different layout which is still trying to use the rails asset pipeline, I instead used the 'timur' layout which uses the new webpack setup.