### PR TITLE
jc-fix-whitelist

### DIFF
--- a/app/models/whitelist.rb
+++ b/app/models/whitelist.rb
@@ -21,13 +21,13 @@ class Whitelist < ActiveRecord::Base
       whitelist = self.for_janus_user(janus_user) if janus_user
     end
 
-    whitelist
+    return whitelist
   end
 
   def self.for_janus_user(janus_user)
-    self.where(email: janus_user.email).first_or_create do |whitelist|
-      whitelist.set_from_janus_user(janus_user)
-    end
+    whitelist = self.where(email: janus_user.email).first_or_create
+    whitelist.set_from_janus_user(janus_user)
+    return whitelist
   end
 
   def set_from_janus_user(janus_user)


### PR DESCRIPTION
There was a bug in the way the whitelist was being persisted.

When a user has a new token, a new whitelist entry is to be created. Due to the way the whitelist object was created it was not being persisted to the DB. This caused the Timur backend to make extraneous requests to Janus for the user permissions.

This branch fixed this bug.

Once the `graft-use-etna` branch is merged we can remove most of this whitelist/permission code since the permissions can be validated from the token.