### PR TITLE
Fix SelectInput to make search page work

### DIFF
--- a/lib/client/jsx/components/inputs/select_input.jsx
+++ b/lib/client/jsx/components/inputs/select_input.jsx
@@ -6,17 +6,20 @@ const NoneOption = (showNone) => (
   : null
 );
 
-const Option = (v) => (
+const Option = (v,i) => (
   Object.keys(v).includes('key', 'value', 'text')
-  ? <option key={v.key} value={v.value}>{ v.text }</option>
-  : <option key={v} value={v}>{ v }</option>
+  ? <option key={v.key} value={i}>{ v.text }</option>
+  : <option key={v} value={i}>{ v }</option>
 );
 
 // This is an input to select one from a list of options
 export default class SelectInput extends Component {
   onChange(evt) {
-    let { value } = evt.target;
-    if (this.props.onChange) this.props.onChange( value == '' ? null : value );
+    let index = evt.target.value;
+    let { onChange, values } = this.props;
+    let value = values[parseInt(index)]
+
+    if (onChange) onChange( value == '' ? null : value );
   }
 
   render() {

--- a/lib/client/jsx/components/inputs/select_input.jsx
+++ b/lib/client/jsx/components/inputs/select_input.jsx
@@ -17,13 +17,12 @@ export default class SelectInput extends Component {
   onChange(evt) {
     let index = evt.target.value;
     let { onChange, values } = this.props;
-    let value = values[parseInt(index)]
+    let value = values[parseInt(index)];
 
     // props.values may be [ { key, value, text } ]
     if (value != null
       && typeof value === 'object'
-      && 'value' in value)
-      value = value.value;
+      && 'value' in value) value = value.value;
 
     if (onChange) onChange( value == '' ? null : value );
   }

--- a/lib/client/jsx/components/inputs/select_input.jsx
+++ b/lib/client/jsx/components/inputs/select_input.jsx
@@ -19,6 +19,12 @@ export default class SelectInput extends Component {
     let { onChange, values } = this.props;
     let value = values[parseInt(index)]
 
+    // props.values may be [ { key, value, text } ]
+    if (value != null
+      && typeof value === 'object'
+      && 'value' in value)
+      value = value.value;
+
     if (onChange) onChange( value == '' ? null : value );
   }
 

--- a/lib/client/jsx/components/inputs/select_input.jsx
+++ b/lib/client/jsx/components/inputs/select_input.jsx
@@ -7,9 +7,9 @@ const NoneOption = (showNone) => (
 );
 
 const Option = (v,i) => (
-  Object.keys(v).includes('key', 'value', 'text')
-  ? <option key={v.key} value={i}>{ v.text }</option>
-  : <option key={v} value={i}>{ v }</option>
+  (v != null && Object.keys(v).includes('value', 'text'))
+  ? <option key={i} value={i}>{ v.text }</option>
+  : <option key={i} value={i}>{ v }</option>
 );
 
 // This is an input to select one from a list of options

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "marked": "^0.3.17",
     "plotly.js": "^1.35.0",
     "prismjs": "^1.12.0",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1",
     "react-move": "^2.7.0",
     "react-plotlyjs": "^0.4.4",
     "react-redux": "^5.0.7",
@@ -35,6 +35,8 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^3.15.0",
     "eslint-plugin-react": "^6.9.0",
     "extract-text-webpack-plugin": "^3.0.2",
@@ -53,12 +55,13 @@
       "**/test/javascript/**/?(*.)(spec|test).js?(x)"
     ],
     "collectCoverageFrom": [
-      "app/assets/javascripts/**/*.js?(x)"
-    ]
+      "lib/client/jsx/**/*.js?(x)"
+    ],
+    "setupTestFrameworkScriptFile": "./test/setup.js"
   },
   "scripts": {
     "lint": "$(npm bin)/eslint --ext .jsx,.js.jsx,.js ./app/assets/javascripts/** ",
     "lintfile": "$(npm bin)/eslint --ext .jsx,.js.jsx,.js ",
-    "test": "jest --coverage"
+    "test": "jest"
   }
 }

--- a/spec/archimedes_spec.rb
+++ b/spec/archimedes_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../app/models/archimedes'
+require_relative '../lib/models/archimedes'
 
 describe ArchimedesController do
   include Rack::Test::Methods

--- a/spec/functions_spec.rb
+++ b/spec/functions_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../app/models/archimedes'
+require_relative '../lib/models/archimedes'
 
 describe Archimedes::Default do
   it 'computes vector length' do

--- a/spec/matrix_spec.rb
+++ b/spec/matrix_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../app/models/archimedes'
+require_relative '../lib/models/archimedes'
 
 describe Archimedes::Matrix do
   it "should create a matrix with bind('rows/cols',M,M,V,V)" do

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../app/models/archimedes'
+require_relative '../lib/models/archimedes'
 
 describe Archimedes::Table do
   it 'should retrieve a table of data from Magma' do

--- a/spec/vector_spec.rb
+++ b/spec/vector_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../app/models/archimedes/vector'
+require_relative '../lib/models/archimedes/vector'
 
 def vector(items)
   Archimedes::Vector.new(items.map{|i| [ nil, i ]})

--- a/test/javascript/actions/magma.test.js
+++ b/test/javascript/actions/magma.test.js
@@ -3,7 +3,7 @@ import thunk from 'redux-thunk';
 import fetch from 'isomorphic-fetch';
 import nock from 'nock';
 import monsters from '../fixtures/monsters';
-import * as actions from '../../../app/assets/javascripts/actions/magma_actions';
+import * as actions from '../../../lib/client/jsx/actions/magma_actions';
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);

--- a/test/javascript/actions/manifest.test.js
+++ b/test/javascript/actions/manifest.test.js
@@ -2,7 +2,7 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import fetch from 'isomorphic-fetch';
 import nock from 'nock';
-import * as actions from '../../../app/assets/javascripts/actions/manifest_actions';
+import * as actions from '../../../lib/client/jsx/actions/manifest_actions';
 import allManifestsResp, { plot } from '../fixtures/all_manifests_response';
 import manifestStore, { manifest } from '../fixtures/manifests_store';
 import manifestResp from '../fixtures/manifest_response';
@@ -74,10 +74,10 @@ describe('async actions', () => {
     const manifestId = 1;
 
     nock('http://www.fake.com')
-      .post(`/${PROJECT_NAME}/manifests/destroy/${manifestId}`)
+      .delete(`/${PROJECT_NAME}/manifests/destroy/${manifestId}`)
       .reply(
         200,
-        {"success":true},
+        { manifest: { id: manifestId } },
         {
           'Access-Control-Allow-Origin': '*',
           'Content-type': 'application/json'

--- a/test/javascript/components/select_input.test.js
+++ b/test/javascript/components/select_input.test.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import SelectInput from '../../../lib/client/jsx/components/inputs/select_input';
+
+describe('SelectInput', () => {
+  it('displays an html select box with options for values in props.values', () => {
+    let values = [ 'nitwit', 'blubber', 'oddment', 'tweak' ];
+    let component = mount(
+      <SelectInput values={ values }/>
+    );
+
+    let p = component.find('option');
+    expect(p.map(i => i.text())).toEqual(values);
+    expect(p.map(i => i.prop('value'))).toEqual([0,1,2,3]);
+  });
+
+  it('emits a value when an option is clicked', () => {
+    let selected_value = null;
+    let onChange = (value) => selected_value = value;
+
+    let values = [ 'nitwit', 'blubber', 'oddment', 'tweak' ];
+    let component = mount(
+      <SelectInput values={ values } onChange={ onChange }/>
+    );
+
+    component.find('option').at(1).simulate('change');
+    expect(selected_value).toEqual('blubber')
+  });
+
+  it('emits a numerical value when an option is clicked', () => {
+    let selected_value = null;
+    let onChange = (value) => selected_value = value;
+
+    let values = [ 1, 100, 1000, 1200 ];
+    let component = mount(
+      <SelectInput values={ values } onChange={ onChange }/>
+    );
+
+    component.find('option').at(2).simulate('change');
+    expect(selected_value).toEqual(1000)
+  });
+
+  let monsters = [
+    { key: 'hydra', value: 'hydra', text: 'Lernean Hydra' },
+    { key: 'boar', value: 'boar', text: 'Erymanthian Boar' },
+    { key: 'birds', value: 'birds', text: 'Stymphalian Birds' }
+  ]
+
+  it('allows setting a text label for each option value', () => {
+    let component = mount(
+      <SelectInput values={ monsters }/>
+    );
+    let p = component.find('option');
+    expect(p.map(i => i.text())).toEqual(monsters.map(({text})=>text));
+  });
+
+  it('selects a label for each value', () => {
+    let selected_value = null;
+    let onChange = (value) => selected_value = value;
+
+
+    let component = mount(
+      <SelectInput values={ monsters } onChange={ onChange }/>
+    );
+
+    component.find('option').at(2).simulate('change');
+    expect(selected_value).toEqual('birds')
+  });
+})

--- a/test/javascript/reducers/manifests.test.js
+++ b/test/javascript/reducers/manifests.test.js
@@ -1,4 +1,4 @@
-import reducer from '../../../app/assets/javascripts/reducers/manifests_reducer';
+import reducer from '../../../lib/client/jsx/reducers/manifests_reducer';
 import manifestStore, { manifest } from '../fixtures/manifests_store'
 
 describe('manifests reducer', () => {

--- a/test/javascript/reducers/plots.test.js
+++ b/test/javascript/reducers/plots.test.js
@@ -1,4 +1,4 @@
-import reducer from '../../../app/assets/javascripts/reducers/plots_reducer';
+import reducer from '../../../lib/client/jsx/reducers/plots_reducer';
 import { plot as testPlot } from '../fixtures/all_manifests_response';
 
 describe('plots reducer', () => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,8 @@
+
+// suppresses a specific React warning (comment raf out to bring it back)
+const raf = global.requestAnimationFrame = (cb) => setTimeout(cb, 0);
+
+const Enzyme = require('enzyme');
+const EnzymeAdapter = require('enzyme-adapter-react-16');
+// Setup enzyme's react adapter
+Enzyme.configure({ adapter: new EnzymeAdapter() });


### PR DESCRIPTION
The main purpose of this branch is to fix the broken state of the search page, which would not allow you to set the page size in your request. The problem was a JSON request to Magma /retrieve being sent with { page: 1, page_size: '25' } - Magma complains that '25' is not a number. The '25' is set by the SelectInput component, which emits the 'value' of the 'option' node in a 'select' component, which is always a string, even if the prop values to SelectInput is an array of Integers. This branch fixes SelectInput so it emits a 25 if the corresponding option is chosen for <SelectInput values={[ 10, 20, 25, 200 ]}/>.

It also adds component tests to describe this behavior, in test/javascripts/components/select_input.test.js. These tests use the 'enzyme' package from airbnb - this is the recommendation of the official React page on how you should test react components. I also updated some old tests to point to lib/ instead of app/.