### PR TITLE
fix bar plot so dots link to new record

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,27 +12,8 @@
     "node": true
   },
   "globals": {
-    "$": false,
     "Routes": false,
-    "React": false,
-    "freshen": false,
-    "dates": false,
-    "marked": false,
-    "magmaActions": false,
-    "messageActions": false,
-    "connect": false,
-    "plotActions": false,
-    "timurActions": false,
-    "Keycode": false,
-    "Matrix": false,
-    "classNames": false,
-    "chroma": false,
-    "Tree": false,
-    "Redux": false,
-    "Set": false,
-    "thunk": false,
-    "TableSet": false,
-    "TableColumn": false
+    "TIMUR_CONFIG": false
   },
   "plugins": [
     "react"

--- a/lib/client/jsx/components/attributes/plot_attributes/bar_plot_attribute.jsx
+++ b/lib/client/jsx/components/attributes/plot_attributes/bar_plot_attribute.jsx
@@ -15,14 +15,14 @@ import * as ConsignmentSelector from '../../../selectors/consignment_selector';
 export class BarPlotAttribute extends GenericPlotAttribute{
   render(){
     let { selected_plot, template, bars } = this.props;
-    if (selected_plot == undefined) return null;
+    if (!selected_plot) return null;
 
     let bar_plot_props = {
       ymin: 0,
       ymax: 1,
       legend: selected_plot.legend,
       plot: selected_plot.layout,
-      model_name: template.name,
+      model_name: template ? template.name : null,
       bars
     };
 

--- a/lib/client/jsx/components/attributes/plot_attributes/bar_plot_attribute.jsx
+++ b/lib/client/jsx/components/attributes/plot_attributes/bar_plot_attribute.jsx
@@ -14,15 +14,16 @@ import * as ConsignmentSelector from '../../../selectors/consignment_selector';
 
 export class BarPlotAttribute extends GenericPlotAttribute{
   render(){
-    if(this.props.selected_plot == undefined) return null;
+    let { selected_plot, template, bars } = this.props;
+    if (selected_plot == undefined) return null;
 
-    let {selected_plot, bars} = this.props;
     let bar_plot_props = {
       ymin: 0,
       ymax: 1,
       legend: selected_plot.legend,
       plot: selected_plot.layout,
-      bars: bars
+      model_name: template.name,
+      bars
     };
 
     return(

--- a/lib/client/jsx/components/plotter/plots/bar_plot.jsx
+++ b/lib/client/jsx/components/plotter/plots/bar_plot.jsx
@@ -42,7 +42,7 @@ export default class BarPlot extends React.Component{
       width={ plot.width }
       height={ plot.height }>
       <PlotCanvas
-        onWheel={ this.onWheel }
+        onWheel={ this.onWheel.bind(this) }
         x={ margin.left } y={ margin.top }
         width={ width }
         height={ height }>
@@ -89,8 +89,8 @@ export default class BarPlot extends React.Component{
 export class BarPlotBar extends React.Component{
   render() {
     let {
-      model_name, heights, x, scale, width, ymin, ymax, color, similar,
-      highlight_names, highlighted_name, category, mouse_handler, select 
+      name, model_name, heights, x, scale, width, ymin, ymax, color, similar,
+      highlight_names, highlighted_name, category, mouse_handler, select
     } = this.props;
 
     return <g className="bar">

--- a/lib/client/jsx/components/plotter/plots/bar_plot.jsx
+++ b/lib/client/jsx/components/plotter/plots/bar_plot.jsx
@@ -12,7 +12,7 @@ export default class BarPlot extends React.Component{
   }
 
   onWheel(event) {
-    var zoom = this.state.zoom
+    let zoom = this.state.zoom
     event.preventDefault()
 
     if (event.deltaY > 0)
@@ -26,23 +26,24 @@ export default class BarPlot extends React.Component{
     this.setState({ zoom: zoom })
   }
   render() {
-    var plot = this.props.plot
-    var margin = plot.margin,
-        width = plot.width - margin.left - margin.right,
-        height = plot.height - margin.top - margin.bottom
+    let { plot, model_name, ymin, ymax, legend, bars } = this.props;
+    let { margin } = plot;
 
-    var zoom_ymax = this.state.zoom * this.props.ymax
+    let width = plot.width - margin.left - margin.right;
+    let height = plot.height - margin.top - margin.bottom;
 
-    var yScale = D3Scale.createScale(
-      [ this.props.ymin, zoom_ymax ],
+    let zoom_ymax = this.state.zoom * ymax;
+
+    let yScale = D3Scale.createScale(
+      [ ymin, zoom_ymax ],
       [ height, 0 ]
     )
 
     return <svg 
-      id={ this.props.plot.name }
+      id={ plot.name }
       className="bar_plot" 
-      width={ this.props.plot.width }
-      height={ this.props.plot.height }>
+      width={ plot.width }
+      height={ plot.height }>
       <PlotCanvas
         onWheel={ this.onWheel }
         x={ margin.left } y={ margin.top }
@@ -50,11 +51,11 @@ export default class BarPlot extends React.Component{
         height={ height }>
       <YAxis x={ -3 }
         scale={ yScale }
-        ymin={ this.props.ymin }
+        ymin={ ymin }
         ymax={ zoom_ymax }
         num_ticks={5}
         tick_width={ 5 }/>
-      <Legend x={ width - margin.right - 30 } y="0" series={ this.props.legend || this.props.bars }/>
+      <Legend x={ width - margin.right - 30 } y="0" series={ legend || bars }/>
       {
         // heights - all of the heights for this group 
         // select - the height index we want to draw special (as a bar)
@@ -62,24 +63,25 @@ export default class BarPlot extends React.Component{
         // highlight_names - the list of highlight names for all items - all
         //     items with the same highlight_name will light up.
         // category - class/category names for the items
-        this.props.bars.map(
+        bars.map(
           (bar,i) => <BarPlotBar key={ i }
+             model_name={ model_name }
              name={ bar.name }
              color={ bar.color }
-             ymax={ zoom_ymax }
-             ymin={ this.props.ymin }
-             width={ 20 }
-             scale={ yScale }
-             x={ 10 + i * 30 }
              heights={ bar.heights }
              select={ bar.select }
              similar={ bar.similar }
+             category={ bar.category }
+             highlight_names={ bar.highlight_names }
+             ymax={ zoom_ymax }
+             ymin={ ymin }
+             width={ 20 }
+             scale={ yScale }
+             x={ 10 + i * 30 }
              mouse_handler={
                (name) => this.setState({ highlighted_name: name })
              }
-             category={ bar.category }
-             highlighted_name={ this.state.highlighted_name }
-             highlight_names={ bar.highlight_names } />
+             highlighted_name={ this.state.highlighted_name } />
         )
       }
       </PlotCanvas>
@@ -89,39 +91,43 @@ export default class BarPlot extends React.Component{
 
 export class BarPlotBar extends React.Component{
   render() {
-    var props = this.props
+    let {
+      model_name, heights, x, scale, width, ymin, ymax, color, similar,
+      highlight_names, highlighted_name, category, mouse_handler, select 
+    } = this.props;
 
     return <g className="bar">
       {
-        props.heights.map( (name,height,i) => {
+        heights.map( (name,height,i) => {
           if (height == null) return null
 
-          if (props.select != null && props.select == i)
+          if (select == i)
             return <rect key={i}
-              x={ props.x }
-              y={ props.scale( height ) - props.scale(props.ymax) }
-              width={ props.width }
-              style={ { stroke: (props.color || "white") } }
-              height={ props.scale(props.ymin) - props.scale( height ) }/>
+              x={ x }
+              y={ scale( height ) - scale(ymax) }
+              width={ width }
+              style={ { stroke: (color || "white") } }
+              height={ scale(ymin) - scale( height ) }/>
           else
             return <Dot key={i} 
-              category={ props.category ? props.category(i) : null }
-              similar={ props.similar ? props.similar[i] : null }
+              model_name={ model_name }
+              category={ category ? category(i) : null }
+              similar={ similar ? similar[i] : null }
               name={ name } 
-              mouse_handler={ props.mouse_handler }
-              x={ props.x + props.width / 2  + ((1000*height) %8) - 4} 
-              y={ props.scale(height) }
-              highlighted={ props.highlight_names[i] == props.highlighted_name }
-              highlight_name={ props.highlight_names[i] }
+              mouse_handler={ mouse_handler }
+              x={ x + width / 2  + ((1000*height) %8) - 4} 
+              y={ scale(height) }
+              highlighted={ highlight_names[i] == highlighted_name }
+              highlight_name={ highlight_names[i] }
              />
         })
       }
       <text textAnchor="start" 
         transform={ 
-          'translate('+props.x+',' +
-              (props.scale(props.ymin) + 15)+') rotate(45)'
+          'translate('+x+',' +
+              (scale(ymin) + 15)+') rotate(45)'
         }>
-        { props.name }
+        { name }
       </text>
     </g>
   }
@@ -133,15 +139,17 @@ export class Dot extends React.Component{
     this.state = { highlighted: false };
   }
   render() {
-    let { highlighted, category, similar, name, highlight_name, mouse_handler, x, y } = this.props;
-    var classes = [
+    let { highlighted, category, similar, model_name, name, highlight_name, mouse_handler, x, y } = this.props;
+    let classes = [
       'dot',
       category,
       highlighted && 'highlighted',
       similar && 'similar'
     ].filter(_=>_).join(' ');
 
-    return <a xlinkHref={ Routes.browse_model_path('sample', name) }>
+    return <a xlinkHref={
+      Routes.browse_model_path(TIMUR_CONFIG.project_name, model_name, name)
+    }>
         <circle className={classes}
           onMouseOver={
             (event) => {

--- a/lib/client/jsx/components/plotter/plots/bar_plot.jsx
+++ b/lib/client/jsx/components/plotter/plots/bar_plot.jsx
@@ -12,18 +12,15 @@ export default class BarPlot extends React.Component{
   }
 
   onWheel(event) {
-    let zoom = this.state.zoom
-    event.preventDefault()
+    let { zoom } = this.state;
+    event.preventDefault();
 
-    if (event.deltaY > 0)
-      zoom = zoom * 0.8
-    else
-      zoom = zoom * 1.2
-    if (zoom < 1e-6)
-      zoom = 1e-6
-    if (zoom > 1)
-      zoom = 1
-    this.setState({ zoom: zoom })
+    if (event.deltaY > 0) zoom = zoom * 0.8;
+    else zoom = zoom * 1.2;
+    if (zoom < 1e-6) zoom = 1e-6;
+    if (zoom > 1) zoom = 1;
+
+    this.setState({zoom});
   }
   render() {
     let { plot, model_name, ymin, ymax, legend, bars } = this.props;
@@ -37,11 +34,11 @@ export default class BarPlot extends React.Component{
     let yScale = D3Scale.createScale(
       [ ymin, zoom_ymax ],
       [ height, 0 ]
-    )
+    );
 
-    return <svg 
+    return <svg
       id={ plot.name }
-      className="bar_plot" 
+      className="bar_plot"
       width={ plot.width }
       height={ plot.height }>
       <PlotCanvas
@@ -85,7 +82,7 @@ export default class BarPlot extends React.Component{
         )
       }
       </PlotCanvas>
-    </svg>
+    </svg>;
   }
 }
 
@@ -99,17 +96,18 @@ export class BarPlotBar extends React.Component{
     return <g className="bar">
       {
         heights.map( (name,height,i) => {
-          if (height == null) return null
+          if (height == null) return null;
 
-          if (select == i)
+          if (select == i) {
             return <rect key={i}
               x={ x }
               y={ scale( height ) - scale(ymax) }
               width={ width }
-              style={ { stroke: (color || "white") } }
-              height={ scale(ymin) - scale( height ) }/>
-          else
-            return <Dot key={i} 
+              style={ { stroke: (color || 'white') } }
+              height={ scale(ymin) - scale( height ) }/>;
+          }
+          else {
+            return <Dot key={i}
               model_name={ model_name }
               category={ category ? category(i) : null }
               similar={ similar ? similar[i] : null }
@@ -119,7 +117,8 @@ export class BarPlotBar extends React.Component{
               y={ scale(height) }
               highlighted={ highlight_names[i] == highlighted_name }
               highlight_name={ highlight_names[i] }
-             />
+             />;
+          }
         })
       }
       <text textAnchor="start" 
@@ -129,7 +128,7 @@ export class BarPlotBar extends React.Component{
         }>
         { name }
       </text>
-    </g>
+    </g>;
   }
 }
 
@@ -153,14 +152,14 @@ export class Dot extends React.Component{
         <circle className={classes}
           onMouseOver={
             (event) => {
-              this.setState({ highlighted: true })
-              mouse_handler(highlight_name) 
+              this.setState({ highlighted: true });
+              mouse_handler(highlight_name);
             }
           }
           onMouseOut={
             (event) => {
-              this.setState({highlighted: false})
-              mouse_handler(null)
+              this.setState({highlighted: false});
+              mouse_handler(null);
             }
           }
           r="2.5"
@@ -174,6 +173,6 @@ export class Dot extends React.Component{
             { name }
           </text> : null
         }
-      </a>
+      </a>;
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "setupTestFrameworkScriptFile": "./test/setup.js"
   },
   "scripts": {
-    "lint": "$(npm bin)/eslint --ext .jsx,.js.jsx,.js ./app/assets/javascripts/** ",
+    "lint": "$(npm bin)/eslint --ext .jsx,.js.jsx,.js ./lib/client/jsx/** ",
     "lintfile": "$(npm bin)/eslint --ext .jsx,.js.jsx,.js ",
     "test": "jest"
   }


### PR DESCRIPTION
This is a fix to the BarPlot, which used to allow users to click through a dot in the bar plot to get to another record (used in the ipi sample "Fingerprint" plot); the functionality seems to have been lost through a function argument being missing as a result of an interface change in Routes.browse_model_path.

Needless to say this structure may not survive upcoming plot changes or client-side routing changes. Most of what you see here is merely formatting and refactoring; the relevant change is adding the model_name as a prop in BarPlotAttribute and passing the project_name to the Routes helper when generating the link.