### PR TITLE
Graft fix json2csv

### DIFF
--- a/lib/client/jsx/utils/tsv.js
+++ b/lib/client/jsx/utils/tsv.js
@@ -1,9 +1,9 @@
-import json2csv from 'json2csv'
+import { parse } from 'json2csv'
 import downloadjs from 'downloadjs'
 
 export const downloadTSV = (data, fields, fileName) => {
   try {
-    var result = json2csv({ data: data, fields: fields, del: '\t'});
+    let result = parse(data, { fields, delimiter: '\t'});
     downloadjs(result, fileName+'.tsv', 'text/tsv');
   } catch (err) {
     // Errors are thrown for bad options, or if the data is empty and no fields are provided.

--- a/test/javascript/utils/tsv.test.js
+++ b/test/javascript/utils/tsv.test.js
@@ -1,0 +1,27 @@
+import { downloadTSV } from '../../../lib/client/jsx/utils/tsv';
+import downloadjs from 'downloadjs';
+jest.mock('downloadjs', ()=>(jest.fn()))
+
+describe('downloadTSV', () => {
+  it('triggers a download', () => {
+    let data = [
+      { labor: 'Nemean Lion', prize: 'hide' },
+      { labor: 'Lernean Hydra', prize: 'arrows' }
+    ];
+    downloadTSV(
+      data, ['labor', 'prize' ], 'labors'
+    )
+
+    let tsv = `"labor"\t"prize"\n${
+      data.map(
+        ({labor,prize})=> `"${labor}"\t"${prize}"`
+      ).join('\n')
+    }`;
+
+    expect(downloadjs).toHaveBeenCalledWith(
+      tsv,
+      'labors.tsv',
+      'text/tsv'
+    );
+  });
+});


### PR DESCRIPTION
There is a bug in production due to the npm package 'json2csv' having been upgraded from v3 to v4 in some indiscriminate package.json update. This PR fixes that big by updating the json2csv call.

It also adds a jest test for the timur 'downloadTSV' util function, which is used by 'VectorResult' and 'MatrixResult' in the ConsignmentResult to download a TSV of data. I'm not sure this is the best test to use.