### PR TITLE
Graft update gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'pg', '~> 0.21'
 gem 'sequel', '4.49.0'
 
 group :development, :test do
-  gem 'spring'
   gem 'rspec'
   gem 'simplecov'
   gem 'pry'
@@ -25,8 +24,4 @@ group :development, :test do
   gem 'factory_bot'
   gem 'database_cleaner'
   gem 'rack-test', require: "rack/test"
-end
-
-group :test, :production do
-  gem 'omniauth-shibboleth'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.1)
+    activesupport (5.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -9,14 +9,14 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     coderay (1.1.2)
-    concurrent-ruby (1.0.5)
+    concurrent-ruby (1.1.4)
     connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
     docile (1.3.1)
-    etna (0.1.3)
+    etna (0.1.4)
       jwt
       rack
     factory_bot (4.11.1)
@@ -24,30 +24,24 @@ GEM
     ffi (1.9.25)
     filigree (0.3.3)
     hashdiff (0.3.7)
-    hashie (3.5.7)
-    i18n (1.1.1)
+    i18n (1.2.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
     jwt (2.1.0)
     magma (0.5.1)
       multipart-post
       net-http-persistent
-    method_source (0.9.0)
+    method_source (0.9.2)
     minitest (5.11.3)
     multipart-post (2.0.0)
     net-http-persistent (3.0.0)
       connection_pool (~> 2.2)
-    omniauth (1.8.1)
-      hashie (>= 3.4.6, < 3.6.0)
-      rack (>= 1.6.2, < 3)
-    omniauth-shibboleth (1.3.0)
-      omniauth (>= 1.0.0)
     pg (0.21.0)
-    pry (0.11.3)
+    pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rltk (3.0.1)
@@ -73,8 +67,6 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    spring (2.0.2)
-      activesupport (>= 4.2)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -92,7 +84,6 @@ DEPENDENCIES
   factory_bot
   filigree (= 0.3.3)
   magma
-  omniauth-shibboleth
   pg (~> 0.21)
   pry
   rack-test
@@ -100,7 +91,6 @@ DEPENDENCIES
   rspec
   sequel (= 4.49.0)
   simplecov
-  spring
   webmock
 
 BUNDLED WITH

--- a/db/migrations/001_initial_migration.rb
+++ b/db/migrations/001_initial_migration.rb
@@ -5,7 +5,7 @@ Sequel.migration do
       Integer :manifest_id, :null=>false
       String :name, :null=>false
       String :plot_type, :null=>false
-      String :configuration, :null=>false
+      json :configuration, :null=>false
       DateTime :created_at, :null=>false
       DateTime :updated_at, :null=>false
       Integer :user_id

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -11,6 +11,11 @@ class Timur
       erb_view(:no_auth)
     end
 
+    # root path
+    get '/', as: :root do
+      erb_view(:client)
+    end
+
     with auth: { user: { can_view?: :project_name } } do
       # browse_controller.rb
       get ':project_name/view/:model_name', action: 'browse#view', as: :view
@@ -31,10 +36,6 @@ class Timur
       delete ':project_name/manifests/destroy/:id', action: 'manifests#destroy'
 
       # remaining view routes are parsed by the client and must also be set there
-      # root path
-      get '/', as: :root do
-        erb_view(:client)
-      end
       get ':project_name', as: :project do
         erb_view(:client)
       end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,37 @@
+describe "View Client" do
+  include Rack::Test::Methods
+
+  def app
+    OUTER_APP
+  end
+
+  context 'root path' do
+    it 'gets the view client for any user' do
+      auth_header(:non_user)
+      get("/")
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to match(/TIMUR_CONFIG/)
+      expect(last_response.body).to match(/"project_name":null/)
+    end
+  end
+
+  context 'project path' do
+    it 'gets the view client for a project user' do
+      auth_header(:viewer)
+      get("/labors")
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to match(/TIMUR_CONFIG/)
+      expect(last_response.body).to match(/"project_name":"labors"/)
+    end
+
+    it 'refuses the view client for a non-user' do
+      auth_header(:non_user)
+      get("/labors")
+
+      expect(last_response.status).to eq(403)
+      expect(last_response.body).to eq('You are forbidden from performing this action.')
+    end
+  end
+end


### PR DESCRIPTION
A wee update that clears some really old dependencies from the Gemfile (as in, circa 2015), and also fixes the root page to show up again instead of being forbidden.

The main purpose of this is to start using Gemfile.lock again during deploys; currently this is being discarded before bundle install (so that staging/production has a fresh Gemfile.lock instead of adhering to the one checked in), however this seems dangerous especially with incrementing etna versions.