### PR TITLE
Graft fix browse slash

### DIFF
--- a/lib/client/jsx/components/link.jsx
+++ b/lib/client/jsx/components/link.jsx
@@ -14,7 +14,7 @@ class Link extends React.Component {
     let { children, link } = this.props;
     return <a
       className='link'
-      onClick={ link.match(/^http/) ? null : this.pushLocation.bind(this) }
+      onClick={ link.match(/^https?:\/\//) ? null : this.pushLocation.bind(this) }
       href={ link } >
       {children}
     </a>

--- a/lib/client/jsx/components/link.jsx
+++ b/lib/client/jsx/components/link.jsx
@@ -3,16 +3,18 @@ import {connect} from 'react-redux';
 import { pushLocation } from '../actions/location_actions';
 
 class Link extends React.Component {
-  render() {
+  pushLocation(event) {
     let { children, link, pushLocation } = this.props;
+
+    event.preventDefault();
+    pushLocation(link);
+  }
+
+  render() {
+    let { children, link } = this.props;
     return <a
       className='link'
-      onClick={
-        (event) => {
-          event.preventDefault();
-          pushLocation(link);
-        }
-      }
+      onClick={ link.match(/^http/) ? null : this.pushLocation.bind(this) }
       href={ link } >
       {children}
     </a>

--- a/lib/client/jsx/timur_router.jsx
+++ b/lib/client/jsx/timur_router.jsx
@@ -117,7 +117,7 @@ const matchRoute = ({ path, hash }, route) => (
 );
 
 const routeParams = ({path,hash}, route) => {
-  let [ _, ...values ] = path.match(route.path_regexp);
+  let [ _, ...values ] = decodeURIComponent(path).match(route.path_regexp);
 
   if (hash) {
     let [ _, ...hash_values ] = hash.match(route.hash_regexp);

--- a/test/javascript/components/timur_router.test.js
+++ b/test/javascript/components/timur_router.test.js
@@ -25,14 +25,25 @@ describe('TimurRouter', () => {
       }
     });
 
-    let component = mount(
-      <TimurRouter store={store}/>
-    );
+    let component = mount(<TimurRouter store={store}/>);
 
     let p = component.find('mock-browser').first();
     expect(p.prop('project_name')).toEqual('labors');
     expect(p.prop('model_name')).toEqual('monster');
     expect(p.prop('record_name')).toEqual('Nemean Lion');
+  });
+
+  it('can deal with encoded slashes params', () => {
+    let component = mount(<TimurRouter store={
+      mockStore({
+        location: {
+          path: '/labors/browse/monster/Nemean Lion%2FLioness'
+        }
+      })
+    }/>);
+
+    let p = component.find('mock-browser').first();
+    expect(p.prop('record_name')).toEqual('Nemean Lion/Lioness');
   });
 
   it('matches hash arguments in the route', () => {


### PR DESCRIPTION
This fixes two unrelated issues caused by the recent single-page client update.

The first was that using the 'browse' component to view records with a slash in the record_name route param was not working: magma would not recognize the record name because it was being sent with an encoded slash (%2F). This was fixed by decoding the path before making a request to magma.

The other was that the Link component, used to route any `<a href/>` clicks through the history API. This, however, failed on ordinary urls (e.g. 'https://github.com/') because the history API does not accept outside URLs. The component was amended to not push history events for such urls. 