### PR TITLE
Graft fix plotter errors

### DIFF
--- a/lib/client/jsx/actions/action_helpers.js
+++ b/lib/client/jsx/actions/action_helpers.js
@@ -1,3 +1,5 @@
+import { showMessages } from './message_actions';
+
 export const showErrors = (dispatch)=> (error) =>
   ('response' in error) ?
     error.response.json().then(

--- a/lib/client/jsx/components/plotter_d3_v5/plotter.jsx
+++ b/lib/client/jsx/components/plotter_d3_v5/plotter.jsx
@@ -261,7 +261,7 @@ class Plotter extends React.Component {
           <div className='ps-list-container'>
             {plot.configuration.plot_series && plot.configuration.plot_series.map((series, index) => (
               <PlotSeries
-                key={`ps-card-container-${index}-${series.name}`}
+                key={`ps-card-container-${index}`}
                 plot_series={series}
                 series_config={plot_config.series_types[ series.series_type]}
                 onDelete={() => {


### PR DESCRIPTION
This mostly fixes the 'name' box on the plot editor so that it allows entry again (previously setting the key based on 'name' broke editing when the value of 'name' changed). It also amends the showErrors function a little bit, but error handling is laughably bad everywhere and needs a lot of work.