### PR TITLE
Fix mis-renamed attribute

### DIFF
--- a/lib/client/jsx/components/model_map.jsx
+++ b/lib/client/jsx/components/model_map.jsx
@@ -109,7 +109,7 @@ class LayoutNode {
   unplacedLinks() {
     // there should only be a single placed link. Return
     // links in circular order after that
-    let index = this.links.findIndex(link => link.other.link_model_name == this.parent_name)
+    let index = this.links.findIndex(link => link.other.model_name == this.parent_name)
     return Array(this.links.length-(index >= 0 ? 1 : 0)).fill().map((_,i) => this.links[(index + i + 1)%this.links.length])
   }
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "jest": "^21.1.0",
     "nock": "^9.0.16",
     "node-sass": "^4.7.2",
+    "raf": "^3.4.1",
+    "react-test-renderer": "^16.4.1",
     "redux-logger": "^3.0.6",
     "redux-mock-store": "^1.3.0",
     "sass-loader": "^6.0.7",
@@ -61,7 +63,10 @@
     "collectCoverageFrom": [
       "lib/client/jsx/**/*.js?(x)"
     ],
-    "setupTestFrameworkScriptFile": "./test/setup.js"
+    "setupTestFrameworkScriptFile": "./test/setup.js",
+    "setupFiles": [
+      "raf/polyfill"
+    ]
   },
   "scripts": {
     "lint": "$(npm bin)/eslint --ext .jsx,.js.jsx,.js ./lib/client/jsx/** ",

--- a/test/javascript/components/__snapshots__/model_map.test.js.snap
+++ b/test/javascript/components/__snapshots__/model_map.test.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModelMap renders 1`] = `
+<div
+  id="map"
+>
+  <svg
+    height={500}
+    width={500}
+  />
+  <div />
+</div>
+`;

--- a/test/javascript/components/model_map.test.js
+++ b/test/javascript/components/model_map.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { mount, shallow } from 'enzyme';
+import renderer from 'react-test-renderer';
+import { mockStore } from '../helpers';
+import ModelMap from '../../../lib/client/jsx/components/model_map';
+
+describe('ModelMap', () => {
+  let store;
+
+  beforeEach(() => {
+    store = mockStore({
+      location: {
+        path: '/labors/browse/monster/Nemean Lion'
+      },
+      magma: {
+        models: {
+          patients: {
+            template: {
+              name: 'patients',
+              attributes: {
+                link_model_name: 'experiment'
+              }
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('renders', () => {
+    global.TIMUR_CONFIG = {
+      magma_host: 'magma.test'
+    };
+
+    // Wrap with Provider here so store gets passed down to child components in Context
+    const tree = renderer
+      .create(
+        <Provider store={store}>
+          <ModelMap />
+        </Provider>
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Looks like one of the `model_name` attributes in Timur was incorrectly re-named to `link_model_name` accidentally in a previous PR. Changing it back to `model_name` fixes the recursion bug we're seeing in the `Map` tab.