### PR TITLE
bump rack to deployed version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.5)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rltk (3.0.1)


### PR DESCRIPTION
Small tweak because running into version mismatch issues on Staging. 

```
 Unable to load application: Gem::LoadError: You have already activated rack 2.2.3, but your Gemfile requires rack 2.2.2
```

So....let's bump this.