### PR TITLE
Cs remove magma client

### DIFF
--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -15,6 +15,8 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+    env:
+      TIMUR_ENV: test
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/ruby-tests.yml
+++ b/.github/workflows/ruby-tests.yml
@@ -28,14 +28,6 @@ jobs:
         uses: actions/setup-ruby@v1
         with:
           ruby-version: 2.5
-      - name: Fetch Magma and compile the gem
-        run: |
-          git clone https://github.com/mountetna/magma.git
-          cd magma/gem
-          gem build magma
-          export GEM_HOME="$GITHUB_WORKSPACE/vendor/bundle/2.5.0"
-          gem install magma
-          gem env
       - name: Bundle install Gems
         run: |
           gem install bundler -v 2.1.4

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,6 @@ gem 'etna'
 gem 'rltk'
 gem 'filigree', '0.3.3'
 
-# client to get data from Magma
-# gem 'magma'
-
 # used by sequel
 gem 'pg', '~> 0.21'
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rltk'
 gem 'filigree', '0.3.3'
 
 # client to get data from Magma
-gem 'magma'
+# gem 'magma'
 
 # used by sequel
 gem 'pg', '~> 0.21'
@@ -20,6 +20,7 @@ group :development, :test do
   gem 'rspec'
   gem 'simplecov'
   gem 'pry'
+  gem 'pry-byebug'
   gem 'webmock'
   gem 'factory_bot'
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.3)
@@ -30,9 +31,6 @@ GEM
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     jwt (2.2.1)
-    magma (0.5.1)
-      multipart-post
-      net-http-persistent
     method_source (1.0.0)
     minitest (5.14.1)
     multipart-post (2.1.1)
@@ -42,6 +40,9 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     public_suffix (4.0.5)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -85,9 +86,9 @@ DEPENDENCIES
   etna
   factory_bot
   filigree (= 0.3.3)
-  magma
   pg (~> 0.21)
   pry
+  pry-byebug
   rack-test
   rltk
   rspec

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+https://github.com/mountetna/timur/workflows/Run%20JavaScript%20tests/badge.svg https://github.com/mountetna/timur/workflows/Run%20Ruby%20tests/badge.svg
+
 # README
 
 Timur is a data browser. It is primarily intended to consume data from Magma, a data warehouse.
@@ -44,6 +46,6 @@ data for use in plots with Timur.
 
 Plots allow data retrieved using a manifest to be graphed in the browser. Timur features a few basic plot types:
 
-1) XY scatter - plot two numerical variables against each other
+1. XY scatter - plot two numerical variables against each other
 
-2) Cluster/heatmap - Plot N numerical variables against each other.
+2. Cluster/heatmap - Plot N numerical variables against each other.

--- a/config.yml.test
+++ b/config.yml.test
@@ -28,3 +28,7 @@
       #:aws_secret_access_key:
   :magma:
     :host: https://magma.test
+  :rtemis:
+    :host: https://rtemis.test
+  :metis:
+    :host: https://metis.test

--- a/config.yml.test
+++ b/config.yml.test
@@ -1,0 +1,28 @@
+---
+
+:test:
+  :db:
+    :database: timur_test
+    :host: localhost
+    :adapter: postgres
+    :user: developer
+    :password: password
+  :host: https://timur.test
+  :log_file: /dev/null
+  :log_level: error
+  :hmac_keys:
+    :timur: haggis
+    :archimedes: pudding
+  :secret_key:
+  :upload_expiration: 60
+  :download_expiration: 60
+  :timur_uid_name: TIMUR_TEST_UID
+  :token_domain: example.org
+  :token_life: 31536000
+  :backup:
+    :directory: 'timur-test-athena'
+    :credentials:
+      :aws_access_key_id: 'SOMEID'
+      :aws_secret_access_key: 'someKey'
+      #:aws_access_key_id:
+      #:aws_secret_access_key:

--- a/config.yml.test
+++ b/config.yml.test
@@ -26,3 +26,5 @@
       :aws_secret_access_key: 'someKey'
       #:aws_access_key_id:
       #:aws_secret_access_key:
+  :magma:
+    :host: https://magma.test

--- a/lib/commands.rb
+++ b/lib/commands.rb
@@ -153,7 +153,6 @@ EOT
         exit 0
       end
       Process.wait
-
     end
 
     def setup(config)

--- a/lib/commands.rb
+++ b/lib/commands.rb
@@ -122,4 +122,37 @@ EOT
       end
     end
   end
+
+  class CreateDb < Etna::Command
+    usage '# create the initial database per config.yml'
+
+    def execute
+      if @no_db
+        create_db if @no_db
+
+        puts "Database is setup. Please run `bin/timur migrate #{@project_name}`."
+      else
+        puts "Database already exists."
+      end
+    end
+
+    def create_db
+      # Create the database only
+
+      puts "Creating database #{@db_config[:database]}"
+      %x{ PGPASSWORD=#{@db_config[:password]} createdb -w -U #{@db_config[:user]} #{@db_config[:database]} }
+
+      Timur.instance.setup_db
+    end
+
+    def setup(config)
+      super
+      @db_config = Timur.instance.config(:db)
+      begin
+        Timur.instance.setup_db
+      rescue Sequel::DatabaseConnectionError
+        @no_db = true
+      end
+    end
+  end
 end

--- a/lib/models/archimedes/functions/question.rb
+++ b/lib/models/archimedes/functions/question.rb
@@ -3,11 +3,46 @@ module Archimedes
     def call
       query, *_ = @args
 
-      response = Magma::Client.instance.query(
-        @token,
-        @project_name,
-        query.to_values
-      )
+      host = Timur.instance.config(:magma).fetch(:host)
+
+      client = Etna::Client.new(
+        "https://#{host}",
+        @token)
+      
+      query_route = client.routes.find { |r| r[:name] == 'query' }
+
+      path = client.route_path(
+        query_route, {})
+      
+      query_params = {
+        project_name: @project_name,
+        query: @query
+      }
+
+      # Now populate the standard headers
+      hmac_params = {
+        method: 'POST',
+        host: host,
+        path: path,
+
+        expiration: (DateTime.now + 10).iso8601,
+        id: 'archimedes',
+        nonce: SecureRandom.hex,
+        headers: query_params,
+      }
+
+      hmac = Etna::Hmac.new(Timur.instance, hmac_params)
+
+      cgi_hash = CGI.parse(hmac.url_params[:query])
+      cgi_hash.delete('X-Etna-Query') # this could be too long for URI
+
+      hmac_params_hash = Hash[cgi_hash.map {|key,values| [key.to_sym, values[0]||true]}]
+      response = client.send(
+        'body_request',
+        Net::HTTP::Post,
+        hmac.url_params[:path] + '?' + URI.encode_www_form(cgi_hash),
+        query_params)
+
       query_answer = JSON.parse(response.body)
 
       # Loop the data and set the data types returned from Magma.

--- a/lib/models/archimedes/functions/question.rb
+++ b/lib/models/archimedes/functions/question.rb
@@ -14,12 +14,10 @@ module Archimedes
         query: query.to_values
       }
 
-      response = client.query(query_params)
-
-      query_answer = JSON.parse(response)
+      query_answer = client.query(query_params)
 
       # Loop the data and set the data types returned from Magma.
-      recursive_parse(query_answer['answer']) do |item|
+      recursive_parse(query_answer[:answer]) do |item|
         case item
         when /^(\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})[+-](\d{2})\:(\d{2})/
           DateTime.parse(item)

--- a/lib/models/archimedes/functions/question.rb
+++ b/lib/models/archimedes/functions/question.rb
@@ -6,7 +6,7 @@ module Archimedes
       host = Timur.instance.config(:magma).fetch(:host)
 
       client = Etna::Client.new(
-        "https://#{host}",
+        host,
         @token)
       
       query_route = client.routes.find { |r| r[:name] == 'query' }
@@ -16,7 +16,7 @@ module Archimedes
       
       query_params = {
         project_name: @project_name,
-        query: @query
+        query: query.to_values
       }
 
       # Now populate the standard headers

--- a/lib/models/archimedes/functions/table.rb
+++ b/lib/models/archimedes/functions/table.rb
@@ -80,10 +80,7 @@ module Archimedes
     end
 
     def response
-      @response ||= JSON.parse(
-        query_response,
-        symbolize_names: true
-      )
+      @response ||= query_response
     end
 
     def answer
@@ -105,6 +102,7 @@ module Archimedes
         project_name: @project_name,
         query: @query
       }
+      
       client.query(query_params)
     end
   end

--- a/lib/models/archimedes/functions/table.rb
+++ b/lib/models/archimedes/functions/table.rb
@@ -97,12 +97,12 @@ module Archimedes
       client = Etna::Client.new(
         host,
         @token)
-      
+
       query_params = {
         project_name: @project_name,
         query: @query
       }
-      
+
       client.query(query_params)
     end
   end

--- a/lib/models/archimedes/functions/table.rb
+++ b/lib/models/archimedes/functions/table.rb
@@ -98,7 +98,7 @@ module Archimedes
       host = Timur.instance.config(:magma).fetch(:host)
 
       client = Etna::Client.new(
-        "https://#{host}",
+        host,
         @token)
       
       query_route = client.routes.find { |r| r[:name] == 'query' }

--- a/lib/models/archimedes/functions/table.rb
+++ b/lib/models/archimedes/functions/table.rb
@@ -81,7 +81,7 @@ module Archimedes
 
     def response
       @response ||= JSON.parse(
-        query_response.body,
+        query_response,
         symbolize_names: true
       )
     end
@@ -101,39 +101,11 @@ module Archimedes
         host,
         @token)
       
-      query_route = client.routes.find { |r| r[:name] == 'query' }
-      
-      path = client.route_path(
-        query_route, {})
-
       query_params = {
         project_name: @project_name,
         query: @query
       }
-
-      # Now populate the standard headers
-      hmac_params = {
-        method: 'POST',
-        host: host,
-        path: path,
-
-        expiration: (DateTime.now + 10).iso8601,
-        id: 'archimedes',
-        nonce: SecureRandom.hex,
-        headers: query_params,
-      }
-
-      hmac = Etna::Hmac.new(Timur.instance, hmac_params)
-
-      cgi_hash = CGI.parse(hmac.url_params[:query])
-      cgi_hash.delete('X-Etna-Query') # this could be too long for URI
-
-      hmac_params_hash = Hash[cgi_hash.map {|key,values| [key.to_sym, values[0]||true]}]
-      client.send(
-        'body_request',
-        Net::HTTP::Post,
-        hmac.url_params[:path] + '?' + URI.encode_www_form(cgi_hash),
-        query_params)
+      client.query(query_params)
     end
   end
 end

--- a/lib/models/archimedes/manifest.rb
+++ b/lib/models/archimedes/manifest.rb
@@ -64,7 +64,7 @@ module Archimedes
       position = current_position.line_offset
       raise Archimedes::LanguageError, "Syntax error in #{line_fragment(line,position)}"
     rescue Etna::Error => e
-      raise Archimedes::LanguageError, e.body
+      raise Archimedes::LanguageError, e.message
     rescue ArgumentError => e
       raise Archimedes::LanguageError, "#{e.message} in #{current_fragment}"
     rescue TypeError => e

--- a/lib/models/archimedes/manifest.rb
+++ b/lib/models/archimedes/manifest.rb
@@ -63,7 +63,7 @@ module Archimedes
       line = current_position.line_number
       position = current_position.line_offset
       raise Archimedes::LanguageError, "Syntax error in #{line_fragment(line,position)}"
-    rescue Magma::ClientError => e
+    rescue Etna::Error => e
       raise Archimedes::LanguageError, e.body
     rescue ArgumentError => e
       raise Archimedes::LanguageError, "#{e.message} in #{current_fragment}"

--- a/lib/server.rb
+++ b/lib/server.rb
@@ -49,7 +49,6 @@ class Timur
     def initialize
       super
       application.setup_db
-      application.setup_magma
     end
   end
 end

--- a/lib/timur.rb
+++ b/lib/timur.rb
@@ -12,8 +12,4 @@ class Timur
 
     require_relative 'models'
   end
-
-  def setup_magma
-    Magma.instance.configure(config(:magma))
-  end
 end

--- a/spec/archimedes/query_spec.rb
+++ b/spec/archimedes/query_spec.rb
@@ -9,15 +9,18 @@ describe Archimedes::Table do
       to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
 
     # Need a RegEx for the URL match here because of the query params
-    stub_request(:post, /https:\/\/magma.test\/query?/)
+    stub_request(:post, /https:\/\/magma.test\/query/)
       .with(
         body: {
-          project_name:'timur', 
+          project_name:'timur',
           query: ['match', ['games', 'patron', 'name', '::equals', 'Zeus'], '::all', [['contestant', 'city'], ['event'], ['score']]]
         }.to_json
       ).to_return(
+        headers: {
+          'Content-Type': 'application/json'
+        },
         body: {
-          answer: [ 
+          answer: [
             [ 1, [ 'athens', 'shot put', 4 ] ],
             [ 2, [ 'athens', 'pankration', 3 ] ],
             [ 3, [ 'sparta', 'shot put', 2 ] ],
@@ -80,6 +83,9 @@ describe Archimedes::Table do
           query: ['contestant', '::all', [ [ 'city' ], ['scores']]]
         }.to_json
       ).to_return(
+        headers: {
+          'Content-Type': 'application/json'
+        },
         body: {
           answer: [
             [ 'Hercules', [ 'Thebes', [ 3, 3, 4 ] ] ],

--- a/spec/archimedes/query_spec.rb
+++ b/spec/archimedes/query_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../lib/models/archimedes'
 describe Archimedes::Table do
   it 'should retrieve a table of data from Magma' do
     route_payload = JSON.generate([
-      {:method=>"POST", :route=>"/query", :name=>"query"}
+      {:method=>"POST", :route=>"/query", :name=>"query", :params=>[]}
     ])
     stub_request(:options, Timur.instance.config(:magma)[:host]).
       to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
@@ -67,7 +67,7 @@ describe Archimedes::Table do
 
   it 'should unpack a matrix column into separate columns' do
     route_payload = JSON.generate([
-      {:method=>"POST", :route=>"/query", :name=>"query"}
+      {:method=>"POST", :route=>"/query", :name=>"query", :params=>[]}
     ])
     stub_request(:options, Timur.instance.config(:magma)[:host]).
       to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})

--- a/spec/archimedes/query_spec.rb
+++ b/spec/archimedes/query_spec.rb
@@ -2,7 +2,14 @@ require_relative '../../lib/models/archimedes'
 
 describe Archimedes::Table do
   it 'should retrieve a table of data from Magma' do
-    stub_request(:post, Timur.instance.config(:magma)[:host]+'/query')
+    route_payload = JSON.generate([
+      {:method=>"POST", :route=>"/query", :name=>"query"}
+    ])
+    stub_request(:options, 'https://' + Timur.instance.config(:magma)[:host]).
+      to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
+
+    # Need a RegEx for the URL match here because of the query params
+    stub_request(:post, /https:\/\/magma.test\/query?/)
       .with(
         body: {
           project_name:'timur', 
@@ -59,7 +66,14 @@ describe Archimedes::Table do
   end
 
   it 'should unpack a matrix column into separate columns' do
-    stub_request(:post, Timur.instance.config(:magma)[:host]+'/query')
+    route_payload = JSON.generate([
+      {:method=>"POST", :route=>"/query", :name=>"query"}
+    ])
+    stub_request(:options, 'https://' + Timur.instance.config(:magma)[:host]).
+      to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
+
+    # Need a RegEx for the URL match here because of the query params
+    stub_request(:post, /https:\/\/magma.test\/query?/)
       .with(
         body: {
           project_name:'timur',

--- a/spec/archimedes/query_spec.rb
+++ b/spec/archimedes/query_spec.rb
@@ -5,7 +5,7 @@ describe Archimedes::Table do
     route_payload = JSON.generate([
       {:method=>"POST", :route=>"/query", :name=>"query"}
     ])
-    stub_request(:options, 'https://' + Timur.instance.config(:magma)[:host]).
+    stub_request(:options, Timur.instance.config(:magma)[:host]).
       to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
 
     # Need a RegEx for the URL match here because of the query params
@@ -69,7 +69,7 @@ describe Archimedes::Table do
     route_payload = JSON.generate([
       {:method=>"POST", :route=>"/query", :name=>"query"}
     ])
-    stub_request(:options, 'https://' + Timur.instance.config(:magma)[:host]).
+    stub_request(:options, Timur.instance.config(:magma)[:host]).
       to_return(status: 200, body: route_payload, headers: {'Content-Type': 'application/json'})
 
     # Need a RegEx for the URL match here because of the query params

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,6 @@ OUTER_APP = Rack::Builder.new do
   use Etna::DescribeRoutes
   run Timur::Server.new
 end
-Magma.instance.configure(Timur.instance.config(:magma))
 
 AUTH_USERS = {
   admin: {


### PR DESCRIPTION
This removes the dependency on the `Magma` gem and instead uses the `Etna::Client` to talk to Magma. This will hopefully make CI and monoetna easier to use, since the `etna` gem is published to RubyGems and we will not have to build `magma` gem manually.

~~**NOTE:** This change requires a new HMAC entry for `archimedes` in both Magma's and Timur's `config.yml` files, that need to have matching values.~~

@graft , is there a way to test that the various Archimedes methods work? `question` still seems to work since Timur can query and fetch data from Magma, but how do I know if the `table` method works? In the Timur UI, is there a specific set of Manifest commands that I can run to verify it still works? The "manifest tutorial" one in the VM seems to work okay, if that is an indicator.