### PR TITLE
allow partial graphs to be drawn in model_map

### DIFF
--- a/lib/client/jsx/components/model_map/tree_layout.jsx
+++ b/lib/client/jsx/components/model_map/tree_layout.jsx
@@ -52,6 +52,8 @@ class LayoutNode {
   }
 
   place(grid, selected_model) {
+    if (!this.depth) return;
+
     let maxpos = grid[this.depth].length;
     let maxdepth = grid.length;
     this.center = {

--- a/test/javascript/components/__snapshots__/model_map.test.js.snap
+++ b/test/javascript/components/__snapshots__/model_map.test.js.snap
@@ -204,3 +204,162 @@ exports[`ModelMap renders 1`] = `
   </div>
 </div>
 `;
+
+exports[`ModelMap renders an incomplete graph 1`] = `
+<div
+  id="model_map"
+>
+  <div
+    className="map"
+  >
+    <div
+      className="heading report_row"
+    >
+      <span
+        className="name"
+      >
+        Project
+      </span>
+       
+      <span
+        className="title"
+      />
+    </div>
+    <svg
+      height={600}
+      width={600}
+    >
+      <defs>
+        <marker
+          id="arrow"
+          markerHeight="3"
+          markerUnits="strokeWidth"
+          markerWidth="3"
+          orient="auto"
+          refX="0"
+          refY="1"
+        >
+          <path
+            d="M0,0 L0,2 L3,1 z"
+          />
+        </marker>
+      </defs>
+    </svg>
+    <div
+      className="model_node selected"
+      onClick={[Function]}
+      style={
+        Object {
+          "left": 300,
+          "top": 300,
+        }
+      }
+    >
+      project
+    </div>
+  </div>
+  <div
+    className="report"
+  >
+    <div
+      className="model_report"
+    >
+      <div
+        className="heading report_row"
+      >
+        <span
+          className="name"
+        >
+          Model
+        </span>
+         
+        <span
+          className="title"
+        >
+          project
+        </span>
+      </div>
+      <div
+        className="heading report_row"
+      >
+        <span
+          className="name"
+        >
+          Attributes
+        </span>
+      </div>
+      <div
+        className="map_attribute report_row"
+      >
+        <span
+          className="type"
+        >
+           
+          identifier
+           
+        </span>
+        <span
+          className="value"
+        >
+          <a
+            className="name"
+            onClick={[Function]}
+          >
+            name
+          </a>
+          <span
+            className="description"
+          >
+            Name for this project
+          </span>
+        </span>
+      </div>
+      <div
+        className="map_attribute report_row"
+      >
+        <span
+          className="type"
+        >
+           
+          collection
+           
+        </span>
+        <span
+          className="value"
+        >
+          <a
+            className="name"
+            onClick={[Function]}
+          >
+            labor
+          </a>
+        </span>
+      </div>
+      <div
+        className="map_attribute report_row"
+      >
+        <span
+          className="type"
+        >
+           
+          table
+           
+        </span>
+        <span
+          className="value"
+        >
+          <a
+            className="name"
+            onClick={[Function]}
+          >
+            codex
+          </a>
+        </span>
+      </div>
+    </div>
+    <div
+      className="attribute_report"
+    />
+  </div>
+</div>
+`;

--- a/test/javascript/components/model_map.test.js
+++ b/test/javascript/components/model_map.test.js
@@ -14,13 +14,34 @@ const models = {
 describe('ModelMap', () => {
   let store;
 
-  beforeEach(() => {
+  it('renders', () => {
     store = mockStore({
       magma: { models }
     });
+
+    global.TIMUR_CONFIG = {
+      magma_host: 'magma.test'
+    };
+
+    // Wrap with Provider here so store gets passed down to child components in Context
+    const tree = renderer
+      .create(
+        <Provider store={store}>
+          <ModelMap />
+        </Provider>
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
   });
 
-  it('renders', () => {
+  it('renders an incomplete graph', () => {
+    let { monster, project } = models;
+
+    store = mockStore({
+      magma: { models: { monster, project } }
+    });
+
     global.TIMUR_CONFIG = {
       magma_host: 'magma.test'
     };


### PR DESCRIPTION
The new map breaks when models load into the store in the "wrong" order - if the store every has a graph state that is disconnected, it will be unable to render and the map will crash. Eventually the graph will be complete and can be drawn properly, but in the meanwhile the map should not crash. This PR we merely decline to draw a model until it is connected to the project graph; once all of the model objects make it into the store this should be fine.